### PR TITLE
add trailing slash to default ignore to specify directories

### DIFF
--- a/internal/mygit/config/config.go
+++ b/internal/mygit/config/config.go
@@ -59,7 +59,7 @@ func Configure(opts ...Opt) error {
 		RefsHeadsDirectory: DefaultRefsHeadsDirectory,
 		DefaultBranch:      DefaultBranch,
 		GitIgnore: []string{ //@todo read from .gitignore
-			".idea",
+			".idea/",
 		},
 	}
 	for _, opt := range opts {

--- a/internal/mygit/ignore/ignore.go
+++ b/internal/mygit/ignore/ignore.go
@@ -19,12 +19,5 @@ func IsIgnored(path string) bool {
 			return true
 		}
 	}
-	// @todo remove special git case
-	if strings.HasPrefix(path, config.DefaultGitDirectory) {
-		return true
-	}
-	if strings.HasPrefix(path, config.Config.GitDirectory) {
-		return true
-	}
-	return false
+	return strings.HasPrefix(path, config.Config.GitDirectory+string(filepath.Separator))
 }


### PR DESCRIPTION
.git is ignoring also .github - changing to .git/ specifies just the .git directory.

Git Ignore semantics have not been implemented (really at all).